### PR TITLE
Fix redis subscriber death

### DIFF
--- a/XConomy-Core/src/main/java/me/yic/xconomy/data/ProcessSyncData.java
+++ b/XConomy-Core/src/main/java/me/yic/xconomy/data/ProcessSyncData.java
@@ -27,7 +27,6 @@ import me.yic.xconomy.info.SyncInfo;
 import me.yic.xconomy.info.SyncType;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.UUID;
 
@@ -67,7 +66,7 @@ public class ProcessSyncData {
             }else{
                 ob.SyncStart();
             }
-        } catch (IOException | ClassNotFoundException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 


### PR DESCRIPTION
Hello. We were running multiple servers with synchronized economy and recently started to have synchronization issues. After squeezing out last drop out of my brains in attempts to fix this, I decided to look into logs (yay, finally!), and here is what I found:

```
[00:00:00] [XConomyRedisSub/WARN]: [XConomy] Error during creation
[00:00:00] [XConomyRedisSub/WARN]: java.lang.IllegalArgumentException: UUID id cannot be null
[00:00:00] [XConomyRedisSub/WARN]:      at com.google.common.base.Preconditions.checkArgument(Preconditions.java:143)
[00:00:00] [XConomyRedisSub/WARN]:      at org.bukkit.craftbukkit.v1_20_R2.CraftServer.getPlayer(CraftServer.java:730)
[00:00:00] [XConomyRedisSub/WARN]:      at org.bukkit.Bukkit.getPlayer(Bukkit.java:722)
[00:00:00] [XConomyRedisSub/WARN]:      at XConomy-Bukkit-2.25.6.jar//me.yic.xconomy.adapter.comp.CPlayer.<init>(CPlayer.java:20)
[00:00:00] [XConomyRedisSub/WARN]:      at XConomy-Bukkit-2.25.6.jar//me.yic.xconomy.data.ProcessSyncData.process(ProcessSyncData.java:63)
[00:00:00] [XConomyRedisSub/WARN]:      at XConomy-Bukkit-2.25.6.jar//me.yic.xconomy.data.redis.RedisSubscriber.onMessage(RedisSubscriber.java:29)
[00:00:00] [XConomyRedisSub/WARN]:      at XConomy-Bukkit-2.25.6.jar//me.yic.xc_libs.redis.jedis.BinaryJedisPubSub.process(BinaryJedisPubSub.java:121)
[00:00:00] [XConomyRedisSub/WARN]:      at XConomy-Bukkit-2.25.6.jar//me.yic.xc_libs.redis.jedis.BinaryJedisPubSub.proceed(BinaryJedisPubSub.java:96)
[00:00:00] [XConomyRedisSub/WARN]:      at XConomy-Bukkit-2.25.6.jar//me.yic.xc_libs.redis.jedis.Jedis.subscribe(Jedis.java:3785)
[00:00:00] [XConomyRedisSub/WARN]:      at XConomy-Bukkit-2.25.6.jar//me.yic.xconomy.data.redis.RedisThread.run(RedisThread.java:37)
[00:00:00] [XConomyRedisSub/ERROR]: [me.yic.xc_libs.redis.jedis.JedisFactory] Error while validating pooled Jedis object.
java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class [B (java.util.ArrayList and [B are in module java.base of loader 'bootstrap')
        at me.yic.xc_libs.redis.jedis.Connection.getStatusCodeReply(Connection.java:243) ~[XConomy-Bukkit-2.25.6.jar:?]
        at me.yic.xc_libs.redis.jedis.Jedis.ping(Jedis.java:356) ~[XConomy-Bukkit-2.25.6.jar:?]
        at me.yic.xc_libs.redis.jedis.JedisFactory.validateObject(JedisFactory.java:221) ~[XConomy-Bukkit-2.25.6.jar:?]
        at me.yic.xc_libs.pool2.pool2.impl.GenericObjectPool.returnObject(GenericObjectPool.java:1033) ~[XConomy-Bukkit-2.25.6.jar:?]
        at me.yic.xc_libs.redis.jedis.util.Pool.returnResource(Pool.java:47) ~[XConomy-Bukkit-2.25.6.jar:?]
        at me.yic.xc_libs.redis.jedis.JedisPool.returnResource(JedisPool.java:383) ~[XConomy-Bukkit-2.25.6.jar:?]
        at me.yic.xconomy.utils.RedisConnection.returnResource(RedisConnection.java:104) ~[XConomy-Bukkit-2.25.6.jar:?]
        at me.yic.xconomy.data.redis.RedisThread.run(RedisThread.java:43) ~[XConomy-Bukkit-2.25.6.jar:?]
```

For some reason redis subscriber receives some invalid packet. I have not investigated further than this (and there is no need). My solution pretty easy (but it works): this commit replaces exceptions that are being catch, so every exception that are being thrown will not cause subscriber to die.

Yep, that is it.

P.S. I know that this log shows XConomy 2.25.6, but the same issue applies to XConomy 2.25.8.