### PR TITLE
Changed importer format to use UUIDs instead of player names

### DIFF
--- a/XConomy-Bukkit/src/main/java/me/yic/xconomy/data/ImportData.java
+++ b/XConomy-Bukkit/src/main/java/me/yic/xconomy/data/ImportData.java
@@ -110,9 +110,9 @@ public class ImportData implements CommandExecutor {
     @SuppressWarnings("ConstantConditions")
     public void ImportBalance() {
         for (OfflinePlayer op : Bukkit.getServer().getOfflinePlayers()) {
-            if (!importdata.contains(op.getName())) {
-                importdata.createSection(op.getName() + ".balance");
-                importdata.set(op.getName() + ".balance", VaultCM.getBalance(op).toString());
+            if (!importdata.contains(op.getUniqueId().toString())) {
+                importdata.createSection(op.getUniqueId().toString() + ".balance");
+                importdata.set(op.getUniqueId() + ".balance", VaultCM.getBalance(op).toString());
             }
         }
         save();

--- a/XConomy-Core/src/main/java/me/yic/xconomy/data/sql/SQLCreateNewAccount.java
+++ b/XConomy-Core/src/main/java/me/yic/xconomy/data/sql/SQLCreateNewAccount.java
@@ -171,7 +171,7 @@ public class SQLCreateNewAccount extends SQL {
             statement.setString(1, UID);
             statement.setString(2, user);
 
-            statement.setDouble(3, ImportData.getBalance(user, XConomyLoad.Config.INITIAL_BAL).doubleValue());
+            statement.setDouble(3, ImportData.getBalance(UID, XConomyLoad.Config.INITIAL_BAL).doubleValue());
 
             int hid = 0;
             if (NonPlayerPlugin.SimpleCheckNonPlayerAccount(user)){


### PR DESCRIPTION
The importer used player names, which caused issues with similar named Java and Geyser players, because the `data.yml` entry for a player named `.TestPlayer` would overwrite the entry for a player called `TestPlayer`. Changing to UUIDs fixes this issue. When I tested this it worked fine, but I'm not sure if I missed something out.