### PR TITLE
Silently arg "-s" for money give/take commands

### DIFF
--- a/XConomy-Core/src/main/java/me/yic/xconomy/command/core/CommandBalance.java
+++ b/XConomy-Core/src/main/java/me/yic/xconomy/command/core/CommandBalance.java
@@ -192,6 +192,10 @@ public class CommandBalance extends CommandCore{
                                     .replace("%amount%", amountFormatted)
                                     .replace("%balance%", DataFormat.shown(newbalance));
 
+                            if (reasonmessages != null && reasonmessages.toString().equals("-s")) {
+                                return true;
+                            }
+
                             if (commndlength == 4) {
                                 message = PREFIX + reasonmessages;
                             }
@@ -238,6 +242,10 @@ public class CommandBalance extends CommandCore{
                                     .replace("%player%", realname)
                                     .replace("%amount%", amountFormatted)
                                     .replace("%balance%", DataFormat.shown(newbalance));
+
+                            if (reasonmessages != null && reasonmessages.toString().equals("-s")) {
+                                return true;
+                            }
 
                             if (commndlength == 4) {
                                 mess = PREFIX + reasonmessages;


### PR DESCRIPTION
Please add the ability to silently use the money give/take commands with the "-s" argument in the reason for give/take.

Example:

money give Player 100 -s
money take Player 100 -s