### PR TITLE
在执行修改余额操作时，使用来自数据库的最新数据

### DIFF
--- a/XConomy-Bukkit/pom.xml
+++ b/XConomy-Bukkit/pom.xml
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.1</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
         <!--BStats-Bukkit-->

--- a/XConomy-Bukkit/src/main/java/me/yic/xconomy/depend/economy/EnterpriseWallet.java
+++ b/XConomy-Bukkit/src/main/java/me/yic/xconomy/depend/economy/EnterpriseWallet.java
@@ -46,8 +46,11 @@ public class EnterpriseWallet extends PlayerWallet {
             return new EconomyAction(getHolder(), false,  "Max balance!");
         }
 
-        DataCon.changeplayerdata("PLUGIN", getPlayer().getUniqueId(), amount, null, null ,null);
-        return new EconomyAction(getHolder(), true,  "");
+        if (DataCon.changeplayerdata("PLUGIN", getPlayer().getUniqueId(), amount, null, null ,null) != null) {
+            return new EconomyAction(getHolder(), true, "");
+        } else {
+            return new EconomyAction(getHolder(), false,  "Money not enough!");
+        }
     }
 
     @Override
@@ -107,8 +110,11 @@ public class EnterpriseWallet extends PlayerWallet {
         }
 
         UUID playeruuid = getPlayer().getUniqueId();
-        DataCon.changeplayerdata("PLUGIN", playeruuid, amount, false, null, null);
-        return new EconomyAction(getHolder(), true, "");
+        if (DataCon.changeplayerdata("PLUGIN", playeruuid, amount, false, null, null) != null) {
+            return new EconomyAction(getHolder(), true, "");
+        } else {
+            return new EconomyAction(getHolder(), false,  "Money not enough!");
+        }
     }
 
     @Override
@@ -131,8 +137,11 @@ public class EnterpriseWallet extends PlayerWallet {
         }
 
         UUID playerUUID = getPlayer().getUniqueId();
-        DataCon.changeplayerdata("PLUGIN", playerUUID, amount, true, null, null);
-        return new EconomyAction(getHolder(), true,  "");
+        if (DataCon.changeplayerdata("PLUGIN", playerUUID, amount, true, null, null) != null) {
+            return new EconomyAction(getHolder(), true, "");
+        } else {
+            return new EconomyAction(getHolder(), false, "Money not enough!");
+        }
     }
 
     @Override

--- a/XConomy-Bukkit/src/main/java/me/yic/xconomy/depend/economy/Vault.java
+++ b/XConomy-Bukkit/src/main/java/me/yic/xconomy/depend/economy/Vault.java
@@ -129,8 +129,11 @@ public class Vault extends AbstractEconomy {
         }
 
         if (isNonPlayerAccount(name)) {
-            DataCon.changeaccountdata("PLUGIN", name, amountFormatted, true, null);
-            return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+            if (DataCon.changeaccountdata("PLUGIN", name, amountFormatted, true, null)) {
+                return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+            } else {
+                return new EconomyResponse(0.0D, getBalance(name), EconomyResponse.ResponseType.FAILURE, "Money not enough!");
+            }
         }
 
         PlayerData pd = DataCon.getPlayerData(name);
@@ -138,8 +141,11 @@ public class Vault extends AbstractEconomy {
             return new EconomyResponse(0.0D, 0.0D, EconomyResponse.ResponseType.FAILURE, "No Account!");
         }
 
-        DataCon.changeplayerdata("PLUGIN", pd.getUniqueId(), amountFormatted, true, null, null);
-        return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+        if (DataCon.changeplayerdata("PLUGIN", pd.getUniqueId(), amountFormatted, true, null, null) != null) {
+            return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+        } else {
+            return new EconomyResponse(0.0D, getBalance(name), EconomyResponse.ResponseType.FAILURE, "Money not enough!");
+        }
     }
 
     @Override
@@ -162,8 +168,11 @@ public class Vault extends AbstractEconomy {
             return new EconomyResponse(0.0D, bal, EconomyResponse.ResponseType.FAILURE, "Max balance!");
         }
 
-        DataCon.changeplayerdata("PLUGIN", pp.getUniqueId(), amountFormatted, true, null, null);
-        return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+        if (DataCon.changeplayerdata("PLUGIN", pp.getUniqueId(), amountFormatted, true, null, null) != null) {
+            return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+        } else {
+            return new EconomyResponse(0.0D, getBalance(pp), EconomyResponse.ResponseType.FAILURE, "Max balance!");
+        }
     }
 
     @Override
@@ -317,8 +326,11 @@ public class Vault extends AbstractEconomy {
         }
 
         if (isNonPlayerAccount(name)) {
-            DataCon.changeaccountdata("PLUGIN", name, amountFormatted, false, null);
-            return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+            if (DataCon.changeaccountdata("PLUGIN", name, amountFormatted, false, null)) {
+                return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+            } else {
+                return new EconomyResponse(0.0D, getBalance(name), EconomyResponse.ResponseType.FAILURE, "Money not enough!");
+            }
         }
 
         PlayerData pd = DataCon.getPlayerData(name);
@@ -326,8 +338,11 @@ public class Vault extends AbstractEconomy {
             return new EconomyResponse(0.0D, 0.0D, EconomyResponse.ResponseType.FAILURE, "No Account!");
         }
 
-        DataCon.changeplayerdata("PLUGIN", pd.getUniqueId(), amountFormatted, false, null, null);
-        return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+        if (DataCon.changeplayerdata("PLUGIN", pd.getUniqueId(), amountFormatted, false, null, null) != null) {
+            return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+        } else {
+            return new EconomyResponse(0.0D, getBalance(name), EconomyResponse.ResponseType.FAILURE, "Max balance!");
+        }
     }
 
     @Override
@@ -350,8 +365,11 @@ public class Vault extends AbstractEconomy {
             return new EconomyResponse(0.0D, bal, EconomyResponse.ResponseType.FAILURE, "Insufficient balance!");
         }
 
-        DataCon.changeplayerdata("PLUGIN", pp.getUniqueId(), amountFormatted, false, null, null);
-        return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+        if (DataCon.changeplayerdata("PLUGIN", pp.getUniqueId(), amountFormatted, false, null, null) != null) {
+            return new EconomyResponse(amount, bal, EconomyResponse.ResponseType.SUCCESS, "");
+        } else {
+            return new EconomyResponse(0.0D, getBalance(pp), EconomyResponse.ResponseType.FAILURE, "Max balance!");
+        }
     }
 
     @Override

--- a/XConomy-Core/src/main/java/me/yic/xconomy/api/XConomyAPI.java
+++ b/XConomy-Core/src/main/java/me/yic/xconomy/api/XConomyAPI.java
@@ -100,8 +100,11 @@ public class XConomyAPI {
                 }
             }
         }
-        DataCon.changeplayerdata("PLUGIN_API", u, amount, isadd, pluginname, null);
-        return 0;
+        if (DataCon.changeplayerdata("PLUGIN_API", u, amount, isadd, pluginname, null) != null) {
+            return 0;
+        } else {
+            return 2;
+        }
     }
 
     @Deprecated
@@ -131,8 +134,11 @@ public class XConomyAPI {
                 }
             }
         }
-        DataCon.changeaccountdata("PLUGIN_API", account, amount, isadd, pluginname);
-        return 0;
+        if (DataCon.changeaccountdata("PLUGIN_API", account, amount, isadd, pluginname)) {
+            return 0;
+        } else {
+            return 2;
+        }
     }
 
     public List<String> getbalancetop() {

--- a/XConomy-Core/src/main/java/me/yic/xconomy/command/core/CommandBalance.java
+++ b/XConomy-Core/src/main/java/me/yic/xconomy/command/core/CommandBalance.java
@@ -181,6 +181,10 @@ public class CommandBalance extends CommandCore{
                         }
 
                         BigDecimal newbalance = DataCon.changeplayerdata("ADMIN_COMMAND", targetUUID, amount, true, com, reasonmessages);
+                        if (newbalance == null) {
+                            sendMessages(sender, PREFIX + translateColorCodes("invalid_amount"));
+                            return true;
+                        }
                         sendMessages(sender, PREFIX + translateColorCodes("money_give")
                                 .replace("%player%", realname)
                                 .replace("%amount%", amountFormatted));
@@ -229,6 +233,12 @@ public class CommandBalance extends CommandCore{
                         }
 
                         BigDecimal newbalance = DataCon.changeplayerdata("ADMIN_COMMAND", targetUUID, amount, false, com, reasonmessages);
+                        if (newbalance == null) {
+                            sendMessages(sender, PREFIX + translateColorCodes("money_take_fail")
+                                    .replace("%player%", realname)
+                                    .replace("%amount%", amountFormatted));
+                            return true;
+                        }
                         sendMessages(sender, PREFIX + translateColorCodes("money_take")
                                 .replace("%player%", realname)
                                 .replace("%amount%", amountFormatted));
@@ -261,6 +271,10 @@ public class CommandBalance extends CommandCore{
                         }
 
                         BigDecimal newbalance = DataCon.changeplayerdata("ADMIN_COMMAND", targetUUID, amount, null, com, reasonmessages);
+                        if (newbalance == null) {
+                            sendMessages(sender, PREFIX + translateColorCodes("invalid_amount"));
+                            return true;
+                        }
                         sendMessages(sender, PREFIX + translateColorCodes("money_set")
                                 .replace("%player%", realname)
                                 .replace("%amount%", amountFormatted));

--- a/XConomy-Core/src/main/java/me/yic/xconomy/command/core/CommandPay.java
+++ b/XConomy-Core/src/main/java/me/yic/xconomy/command/core/CommandPay.java
@@ -129,7 +129,11 @@ public class CommandPay extends CommandCore{
         }
 
         String com = commandName + " " + args[0] + " " + amount;
-        DataCon.changeplayerdata("PLAYER_COMMAND", sender.toPlayer().getUniqueId(), taxamount, false, com, null);
+        if (DataCon.changeplayerdata("PLAYER_COMMAND", sender.toPlayer().getUniqueId(), taxamount, false, com, null) == null) {
+            sendMessages(sender, PREFIX + translateColorCodes("pay_fail")
+                    .replace("%amount%", taxamountFormatted));
+            return true;
+        }
         sendMessages(sender, PREFIX + translateColorCodes("pay")
                 .replace("%player%", realname)
                 .replace("%amount%", amountFormatted));

--- a/XConomy-Core/src/main/java/me/yic/xconomy/data/DataCon.java
+++ b/XConomy-Core/src/main/java/me/yic/xconomy/data/DataCon.java
@@ -26,6 +26,7 @@ import me.yic.xconomy.adapter.comp.CallAPI;
 import me.yic.xconomy.data.caches.Cache;
 import me.yic.xconomy.data.caches.CacheNonPlayer;
 import me.yic.xconomy.data.redis.RedisPublisher;
+import me.yic.xconomy.data.sql.SQL;
 import me.yic.xconomy.data.syncdata.PlayerData;
 import me.yic.xconomy.data.syncdata.SyncBalanceAll;
 import me.yic.xconomy.data.syncdata.SyncData;
@@ -39,6 +40,15 @@ import java.math.BigDecimal;
 import java.util.UUID;
 
 public class DataCon {
+
+    public static PlayerData refreshPlayerData(UUID uuid) {
+        SQL.getPlayerData(uuid);
+        PlayerData pd = Cache.getDataFromCache(uuid);
+        if (AdapterManager.PLUGIN.getOnlinePlayersisEmpty()) {
+            Cache.clearCache();
+        }
+        return pd;
+    }
 
     public static PlayerData getPlayerData(UUID uuid) {
         return getPlayerDatai(uuid);
@@ -128,7 +138,7 @@ public class DataCon {
     }
 
     public static BigDecimal changeplayerdata(final String type, final UUID uid, final BigDecimal amount, final Boolean isAdd, final String command, final Object comment) {
-        PlayerData pd = getPlayerData(uid);
+        PlayerData pd = refreshPlayerData(uid);
         UUID u = pd.getUniqueId();
         BigDecimal newvalue = amount;
         BigDecimal bal = pd.getBalance();
@@ -143,6 +153,9 @@ public class DataCon {
             } else {
                 newvalue = bal.subtract(amount);
             }
+        }
+        if (newvalue.doubleValue() < 0) {
+            return null;
         }
 
         Cache.updateIntoCache(u, pd, newvalue, bal);
@@ -166,9 +179,9 @@ public class DataCon {
 
 
     @SuppressWarnings("ConstantConditions")
-    public static void changeaccountdata(final String type, final String u, final BigDecimal amount, final Boolean isAdd, final String command) {
+    public static boolean changeaccountdata(final String type, final String u, final BigDecimal amount, final Boolean isAdd, final String command) {
         BigDecimal newvalue = amount;
-        BigDecimal balance = getAccountBalance(u);
+        BigDecimal balance = DataLink.getBalNonPlayer(u);
 
         RecordInfo ri = new RecordInfo(type, command, null);
 
@@ -180,6 +193,9 @@ public class DataCon {
                 newvalue = balance.subtract(amount);
             }
         }
+        if (newvalue.doubleValue() < 0) {
+            return false;
+        }
         CacheNonPlayer.insertIntoCache(u, newvalue);
 
         if (XConomyLoad.DConfig.canasync && AdapterManager.checkisMainThread()) {
@@ -188,6 +204,7 @@ public class DataCon {
         } else {
             DataLink.saveNonPlayer(u, amount, newvalue, isAdd, ri);
         }
+        return true;
     }
 
     public static void changeallplayerdata(String targettype, String type, BigDecimal amount, Boolean isAdd, String command, StringBuilder comment) {

--- a/XConomy-Sponge7/src/main/java/me/yic/xconomy/depend/economyapi/XCUniqueAccount.java
+++ b/XConomy-Sponge7/src/main/java/me/yic/xconomy/depend/economyapi/XCUniqueAccount.java
@@ -108,9 +108,17 @@ public class XCUniqueAccount implements UniqueAccount {
                     DummyObjectProvider.createFor(TransactionType.class, "SET"));
         }
         if (isplayer) {
-            DataCon.changeplayerdata("PLUGIN", uuid, amount, null, "SETBALANCE", null);
+            if (DataCon.changeplayerdata("PLUGIN", uuid, amount, null, "SETBALANCE", null) == null) {
+                return new XCTransactionResult(this,
+                        currency, BigDecimal.ZERO, contexts, ResultType.FAILED,
+                        DummyObjectProvider.createFor(TransactionType.class, "SET"));
+            }
         }else{
-            DataCon.changeaccountdata("PLUGIN", name, amount, null, "SETBALANCE");
+            if (!DataCon.changeaccountdata("PLUGIN", name, amount, null, "SETBALANCE")) {
+                return new XCTransactionResult(this,
+                        currency, BigDecimal.ZERO, contexts, ResultType.FAILED,
+                        DummyObjectProvider.createFor(TransactionType.class, "SET"));
+            }
         }
         return new XCTransactionResult(this,
                 currency, BigDecimal.ZERO, contexts, ResultType.SUCCESS,
@@ -155,9 +163,15 @@ public class XCUniqueAccount implements UniqueAccount {
         }
 
         if (isplayer) {
-            DataCon.changeplayerdata("PLUGIN", uuid, amountFormatted, true, null, null);
+            if (DataCon.changeplayerdata("PLUGIN", uuid, amountFormatted, true, null, null) == null) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.DEPOSIT);
+            }
         }else{
-            DataCon.changeaccountdata("PLUGIN", name, amountFormatted, true, null);
+            if (!DataCon.changeaccountdata("PLUGIN", name, amountFormatted, true, null)) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.DEPOSIT);
+            }
         }
         return new XCTransactionResult(this,
                 currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.DEPOSIT);
@@ -180,9 +194,15 @@ public class XCUniqueAccount implements UniqueAccount {
         }
 
         if (isplayer) {
-            DataCon.changeplayerdata("PLUGIN", uuid, amountFormatted, false, null, null);
+            if (DataCon.changeplayerdata("PLUGIN", uuid, amountFormatted, false, null, null) == null) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
+            }
         }else{
-            DataCon.changeaccountdata("PLUGIN", name, amountFormatted, false, null);
+            if (!DataCon.changeaccountdata("PLUGIN", name, amountFormatted, false, null)) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
+            }
         }
         return new XCTransactionResult(this,
                 currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.WITHDRAW);

--- a/XConomy-Sponge7/src/main/java/me/yic/xconomy/depend/economyapi/XCVirtualAccount.java
+++ b/XConomy-Sponge7/src/main/java/me/yic/xconomy/depend/economyapi/XCVirtualAccount.java
@@ -99,10 +99,15 @@ public class XCVirtualAccount implements VirtualAccount {
                     DummyObjectProvider.createFor(TransactionType.class, "SET"));
         }
         if (XCEconomyCommon.isNonPlayerAccount(account)) {
-            DataCon.changeaccountdata("PLUGIN",  account, amount, null, null);
-            return new XCTransactionResult(this,
-                    currency, BigDecimal.ZERO, contexts, ResultType.SUCCESS,
-                    DummyObjectProvider.createFor(TransactionType.class, "SET"));
+            if (DataCon.changeaccountdata("PLUGIN",  account, amount, null, null)) {
+                return new XCTransactionResult(this,
+                        currency, BigDecimal.ZERO, contexts, ResultType.SUCCESS,
+                        DummyObjectProvider.createFor(TransactionType.class, "SET"));
+            } else {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED,
+                        DummyObjectProvider.createFor(TransactionType.class, "SET"));
+            }
         }
         PlayerData pd = DataCon.getPlayerData(account);
         if (pd == null) {
@@ -111,10 +116,15 @@ public class XCVirtualAccount implements VirtualAccount {
                     DummyObjectProvider.createFor(TransactionType.class, "SET"));
         }
         UUID playeruuid = pd.getUniqueId();
-        DataCon.changeplayerdata("PLUGIN", playeruuid, amount, null, "SETBALANCE", null);
-        return new XCTransactionResult(this,
-                currency, BigDecimal.ZERO, contexts, ResultType.SUCCESS,
-                DummyObjectProvider.createFor(TransactionType.class, "SET"));
+        if (DataCon.changeplayerdata("PLUGIN", playeruuid, amount, null, "SETBALANCE", null) != null) {
+            return new XCTransactionResult(this,
+                    currency, BigDecimal.ZERO, contexts, ResultType.SUCCESS,
+                    DummyObjectProvider.createFor(TransactionType.class, "SET"));
+        } else {
+            return new XCTransactionResult(this,
+                    currency, amount, contexts, ResultType.FAILED,
+                    DummyObjectProvider.createFor(TransactionType.class, "SET"));
+        }
     }
 
     @Override
@@ -165,9 +175,13 @@ public class XCVirtualAccount implements VirtualAccount {
         }
 
         if (XCEconomyCommon.isNonPlayerAccount(account)) {
-            DataCon.changeaccountdata("PLUGIN", account, amount, true, null);
-            return new XCTransactionResult(this,
-                    currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.DEPOSIT);
+            if (DataCon.changeaccountdata("PLUGIN", account, amount, true, null)) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.DEPOSIT);
+            } else {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.DEPOSIT);
+            }
         }
         PlayerData pd = DataCon.getPlayerData(account);
         if (pd == null) {
@@ -175,10 +189,13 @@ public class XCVirtualAccount implements VirtualAccount {
                     currency, BigDecimal.ZERO, contexts, ResultType.FAILED, TransactionTypes.DEPOSIT);
         }
         UUID playeruuid = pd.getUniqueId();
-        DataCon.changeplayerdata("PLUGIN", playeruuid, amountFormatted, true, null, null);
-        return new XCTransactionResult(this,
-                currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.DEPOSIT);
-
+        if (DataCon.changeplayerdata("PLUGIN", playeruuid, amountFormatted, true, null, null) != null) {
+            return new XCTransactionResult(this,
+                    currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.DEPOSIT);
+        } else {
+            return new XCTransactionResult(this,
+                    currency, amount, contexts, ResultType.FAILED, TransactionTypes.DEPOSIT);
+        }
     }
 
     @Override
@@ -196,9 +213,13 @@ public class XCVirtualAccount implements VirtualAccount {
                     currency, amount, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
         }
         if (XCEconomyCommon.isNonPlayerAccount(account)) {
-            DataCon.changeaccountdata("PLUGIN", account, amount, false, null);
-            return new XCTransactionResult(this,
-                    currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.WITHDRAW);
+            if (DataCon.changeaccountdata("PLUGIN", account, amount, false, null)) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.WITHDRAW);
+            } else {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
+            }
         }
         PlayerData pd = DataCon.getPlayerData(account);
         if (pd == null) {
@@ -206,9 +227,13 @@ public class XCVirtualAccount implements VirtualAccount {
                     currency, BigDecimal.ZERO, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
         }
         UUID playeruuid = pd.getUniqueId();
-        DataCon.changeplayerdata("PLUGIN", playeruuid, amountFormatted, false, null, null);
-        return new XCTransactionResult(this,
-                currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.WITHDRAW);
+        if (DataCon.changeplayerdata("PLUGIN", playeruuid, amountFormatted, false, null, null) != null) {
+            return new XCTransactionResult(this,
+                    currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.WITHDRAW);
+        } else {
+            return new XCTransactionResult(this,
+                    currency, amount, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
+        }
     }
 
     @Override

--- a/XConomy-Sponge8/src/main/java/me/yic/xconomy/depend/economyapi/XCUniqueAccount.java
+++ b/XConomy-Sponge8/src/main/java/me/yic/xconomy/depend/economyapi/XCUniqueAccount.java
@@ -121,9 +121,15 @@ public class XCUniqueAccount implements UniqueAccount {
                     currency, amount, contexts, ResultType.FAILED);
         }
         if (isplayer) {
-            DataCon.changeplayerdata("PLUGIN", uuid, amount, null, "SETBALANCE", null);
+            if (DataCon.changeplayerdata("PLUGIN", uuid, amount, null, "SETBALANCE", null) == null) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED);
+            }
         }else{
-            DataCon.changeaccountdata("PLUGIN", name, amount, null, "SETBALANCE");
+            if (!DataCon.changeaccountdata("PLUGIN", name, amount, null, "SETBALANCE")) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED);
+            }
         }
         return new XCTransactionResult(this,
                 currency, BigDecimal.ZERO, contexts, ResultType.SUCCESS);
@@ -179,9 +185,15 @@ public class XCUniqueAccount implements UniqueAccount {
                     currency, amount, contexts, ResultType.FAILED, TransactionTypes.DEPOSIT);
         }
         if (isplayer) {
-            DataCon.changeplayerdata("PLUGIN", uuid, amountFormatted, true, null, null);
+            if (DataCon.changeplayerdata("PLUGIN", uuid, amountFormatted, true, null, null) == null) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.DEPOSIT);
+            }
         }else{
-            DataCon.changeaccountdata("PLUGIN", name, amountFormatted, true, null);
+            if (!DataCon.changeaccountdata("PLUGIN", name, amountFormatted, true, null)) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.DEPOSIT);
+            }
         }
         return new XCTransactionResult(this,
                 currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.DEPOSIT);
@@ -208,9 +220,15 @@ public class XCUniqueAccount implements UniqueAccount {
                     currency, amount, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
         }
         if (isplayer) {
-            DataCon.changeplayerdata("PLUGIN", uuid, amountFormatted, false, null, null);
+            if (DataCon.changeplayerdata("PLUGIN", uuid, amountFormatted, false, null, null) == null) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
+            }
         }else{
-            DataCon.changeaccountdata("PLUGIN", name, amountFormatted, false, null);
+            if (!DataCon.changeaccountdata("PLUGIN", name, amountFormatted, false, null)) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
+            }
         }
         return new XCTransactionResult(this,
                 currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.WITHDRAW);

--- a/XConomy-Sponge8/src/main/java/me/yic/xconomy/depend/economyapi/XCVirtualAccount.java
+++ b/XConomy-Sponge8/src/main/java/me/yic/xconomy/depend/economyapi/XCVirtualAccount.java
@@ -112,9 +112,13 @@ public class XCVirtualAccount implements VirtualAccount {
                     currency, amount, contexts, ResultType.FAILED);
         }
         if (XCEconomyCommon.isNonPlayerAccount(account)) {
-            DataCon.changeaccountdata("PLUGIN",  account, amount, null, null);
-            return new XCTransactionResult(this,
-                    currency, BigDecimal.ZERO, contexts, ResultType.SUCCESS);
+            if (DataCon.changeaccountdata("PLUGIN",  account, amount, null, null)) {
+                return new XCTransactionResult(this,
+                        currency, BigDecimal.ZERO, contexts, ResultType.SUCCESS);
+            } else {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED);
+            }
         }
         PlayerData pd = DataCon.getPlayerData(account);
         if (pd == null) {
@@ -122,9 +126,13 @@ public class XCVirtualAccount implements VirtualAccount {
                     currency, BigDecimal.ZERO, contexts, ResultType.FAILED);
         }
         UUID playeruuid = pd.getUniqueId();
-        DataCon.changeplayerdata("PLUGIN", playeruuid, amount, null, "SETBALANCE", null);
-        return new XCTransactionResult(this,
-                currency, BigDecimal.ZERO, contexts, ResultType.SUCCESS);
+        if (DataCon.changeplayerdata("PLUGIN", playeruuid, amount, null, "SETBALANCE", null) != null) {
+            return new XCTransactionResult(this,
+                    currency, BigDecimal.ZERO, contexts, ResultType.SUCCESS);
+        } else {
+            return new XCTransactionResult(this,
+                    currency, amount, contexts, ResultType.FAILED);
+        }
     }
 
     @Override
@@ -186,9 +194,13 @@ public class XCVirtualAccount implements VirtualAccount {
         }
 
         if (XCEconomyCommon.isNonPlayerAccount(account)) {
-            DataCon.changeaccountdata("PLUGIN", account, amount, true, null);
-            return new XCTransactionResult(this,
-                    currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.DEPOSIT);
+            if (DataCon.changeaccountdata("PLUGIN", account, amount, true, null)) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.DEPOSIT);
+            } else {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.DEPOSIT);
+            }
         }
         PlayerData pd = DataCon.getPlayerData(account);
         if (pd == null) {
@@ -196,10 +208,13 @@ public class XCVirtualAccount implements VirtualAccount {
                     currency, BigDecimal.ZERO, contexts, ResultType.FAILED, TransactionTypes.DEPOSIT);
         }
         UUID playeruuid = pd.getUniqueId();
-        DataCon.changeplayerdata("PLUGIN", playeruuid, amountFormatted, true, null, null);
-        return new XCTransactionResult(this,
-                currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.DEPOSIT);
-
+        if (DataCon.changeplayerdata("PLUGIN", playeruuid, amountFormatted, true, null, null) != null) {
+            return new XCTransactionResult(this,
+                    currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.DEPOSIT);
+        } else {
+            return new XCTransactionResult(this,
+                    currency, amount, contexts, ResultType.FAILED, TransactionTypes.DEPOSIT);
+        }
     }
 
     @Override
@@ -222,9 +237,13 @@ public class XCVirtualAccount implements VirtualAccount {
                     currency, amount, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
         }
         if (XCEconomyCommon.isNonPlayerAccount(account)) {
-            DataCon.changeaccountdata("PLUGIN", account, amount, false, null);
-            return new XCTransactionResult(this,
-                    currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.WITHDRAW);
+            if (DataCon.changeaccountdata("PLUGIN", account, amount, false, null)) {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.WITHDRAW);
+            } else {
+                return new XCTransactionResult(this,
+                        currency, amount, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
+            }
         }
         PlayerData pd = DataCon.getPlayerData(account);
         if (pd == null) {
@@ -232,9 +251,13 @@ public class XCVirtualAccount implements VirtualAccount {
                     currency, BigDecimal.ZERO, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
         }
         UUID playeruuid = pd.getUniqueId();
-        DataCon.changeplayerdata("PLUGIN", playeruuid, amountFormatted, false, null, null);
-        return new XCTransactionResult(this,
-                currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.WITHDRAW);
+        if (DataCon.changeplayerdata("PLUGIN", playeruuid, amountFormatted, false, null, null) != null) {
+            return new XCTransactionResult(this,
+                    currency, amount, contexts, ResultType.SUCCESS, TransactionTypes.WITHDRAW);
+        } else {
+            return new XCTransactionResult(this,
+                    currency, amount, contexts, ResultType.FAILED, TransactionTypes.WITHDRAW);
+        }
     }
 
     @Override


### PR DESCRIPTION
注意到 `DataCon.changeplayerdata` 和 `DataCon.changeaccountdata` 在修改账户余额时，都是优先读取当前子服的缓存的余额。
这会造成一个安全隐患，如果跨服通信消息没有及时发送到另一个子服通知更新缓存，那么玩家将有可能借助在两个子服中，余额数据不同的这一问题，达到刷金币的目的。

事实也如此。在跨服通信已启用，并确定转账、Vault 扣费等可以正常同步余额的情况下。玩家A在切换子服的瞬间利用作弊客户端执行命令，转账给玩家B；玩家B在玩家A切换子服的瞬间，在当前子服使用 QuickShop 收购商店扣除玩家A的余额。这样即可达成刷金币的目的。

刷金币的流程来自其它服主查询日志得出的结论，没有复现视频，但可以确定的是，刷金币这件事已经发生了。

在修改余额时，从数据库读取余额也许是更好的选择，数据库有严格的锁机制，比切换服务器时同步数据更加安全。