### PR TITLE
Add configurable duplicate username conflict resolution

### DIFF
--- a/XConomy-Core/src/main/java/me/yic/xconomy/data/sql/SQLCreateNewAccount.java
+++ b/XConomy-Core/src/main/java/me/yic/xconomy/data/sql/SQLCreateNewAccount.java
@@ -20,6 +20,7 @@ package me.yic.xconomy.data.sql;
 
 import me.yic.xconomy.XConomy;
 import me.yic.xconomy.XConomyLoad;
+import me.yic.xconomy.adapter.comp.CConfig;
 import me.yic.xconomy.adapter.comp.CPlayer;
 import me.yic.xconomy.data.DataCon;
 import me.yic.xconomy.data.DataFormat;
@@ -29,9 +30,11 @@ import me.yic.xconomy.data.caches.Cache;
 import me.yic.xconomy.data.syncdata.PlayerData;
 import me.yic.xconomy.data.syncdata.SyncUUID;
 import me.yic.xconomy.depend.NonPlayerPlugin;
+import me.yic.xconomy.utils.DuplicateUsernameAction;
 import me.yic.xconomy.utils.UUIDMode;
 
 import java.math.BigDecimal;
+import java.net.URL;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -142,11 +145,22 @@ public class SQLCreateNewAccount extends SQL {
             if (rs.next()) {
                 String uid = rs.getString(1);
                 if (!uuid.toString().equals(uid)) {
-                    doubledata = true;
                     if (!XConomyLoad.Config.UUIDMODE.equals(UUIDMode.SEMIONLINE)) {
-                        kickplayer(player, 0, uid);
+                        DuplicateUsernameAction action = XConomyLoad.Config.DUPLICATE_USERNAME_ACTION;
+                        if (action == DuplicateUsernameAction.REPLACE) {
+                            resolveConflictReplace(uid, name, connection);
+                            // doubledata stays false → selectUser() will run normally
+                        } else if (action == DuplicateUsernameAction.MOJANG) {
+                            resolveConflictMojang(uid, name, connection);
+                            // doubledata stays false → selectUser() will run normally
+                        } else {
+                            // KICK (default)
+                            doubledata = true;
+                            kickplayer(player, 0, uid);
+                        }
                     } else {
                         createDUUIDLink(uuid.toString(), uid, connection);
+                        doubledata = true;
                     }
                 }
             }
@@ -157,6 +171,74 @@ public class SQLCreateNewAccount extends SQL {
             e.printStackTrace();
         }
         return doubledata;
+    }
+
+    /**
+     * Resolves a duplicate-username conflict by renaming the old UUID entry to a
+     * placeholder (the UUID string itself) so the connecting player can proceed.
+     *
+     * @param oldUid     UUID string of the existing conflicting database entry
+     * @param oldName    the shared username that caused the conflict
+     * @param connection active database connection
+     */
+    private static void resolveConflictReplace(String oldUid, String oldName, Connection connection) {
+        // Use the UUID (without dashes) as a unique placeholder name for the old entry.
+        // The balance is preserved. When the original owner next logs in, their name
+        // will be updated automatically by selectUser().
+        String placeholder = oldUid.replace("-", "");
+        updateUser(oldUid, placeholder, connection);
+        syncOnlineUUID(oldName, placeholder, UUID.fromString(oldUid));
+        XConomy.getInstance().logger(null, 0,
+                "[XConomy] Duplicate username conflict resolved (REPLACE): "
+                        + oldName + " | Old UUID: " + oldUid
+                        + " | Placeholder name set to: " + placeholder);
+    }
+
+    /**
+     * Resolves a duplicate-username conflict by querying the Mojang API for the old
+     * UUID's current username and updating the database record accordingly.
+     * Falls back to {@link #resolveConflictReplace} when the API is unreachable.
+     *
+     * @param oldUid     UUID string of the existing conflicting database entry
+     * @param oldName    the shared username that caused the conflict
+     * @param connection active database connection
+     */
+    private static void resolveConflictMojang(String oldUid, String oldName, Connection connection) {
+        String newNameForOld = fetchCurrentUsernameFromMojang(oldUid);
+        if (newNameForOld != null && !newNameForOld.isEmpty()) {
+            updateUser(oldUid, newNameForOld, connection);
+            syncOnlineUUID(oldName, newNameForOld, UUID.fromString(oldUid));
+            XConomy.getInstance().logger(null, 0,
+                    "[XConomy] Duplicate username conflict resolved (MOJANG): "
+                            + oldName + " | Old UUID: " + oldUid
+                            + " | Updated to current Mojang name: " + newNameForOld);
+        } else {
+            // Mojang API unavailable – fall back to REPLACE behaviour
+            XConomy.getInstance().logger(null, 1,
+                    "[XConomy] Mojang API lookup failed for UUID: " + oldUid
+                            + " | Falling back to REPLACE behaviour");
+            resolveConflictReplace(oldUid, oldName, connection);
+        }
+    }
+
+    /**
+     * Queries the Mojang session-server API for the current username of the given
+     * UUID. Returns {@code null} when the request fails or the profile is not found.
+     *
+     * @param uid UUID string (with dashes) of the player to look up
+     * @return current Mojang username, or {@code null} on failure
+     */
+    private static String fetchCurrentUsernameFromMojang(String uid) {
+        try {
+            String uuidNoDashes = uid.replace("-", "");
+            URL url = new URL("https://sessionserver.mojang.com/session/minecraft/profile/" + uuidNoDashes);
+            CConfig profile = new CConfig(url);
+            return profile.getString("name");
+        } catch (Exception e) {
+            XConomy.getInstance().logger(null, 1,
+                    "[XConomy] Failed to fetch Mojang profile for UUID: " + uid);
+            return null;
+        }
     }
 
 

--- a/XConomy-Core/src/main/java/me/yic/xconomy/info/DefaultConfig.java
+++ b/XConomy-Core/src/main/java/me/yic/xconomy/info/DefaultConfig.java
@@ -20,6 +20,7 @@ package me.yic.xconomy.info;
 
 import me.yic.xconomy.XConomy;
 import me.yic.xconomy.adapter.comp.CConfig;
+import me.yic.xconomy.utils.DuplicateUsernameAction;
 import me.yic.xconomy.utils.UUIDMode;
 
 import java.math.BigDecimal;
@@ -36,6 +37,7 @@ public class DefaultConfig {
         setnonplayeraccount();
         setformatbalance();
         setpaytips();
+        setDuplicateUsernameAction();
     }
     public boolean ISOLDCONFIG = false;
 
@@ -56,6 +58,7 @@ public class DefaultConfig {
     public boolean TRANSACTION_RECORD = config.getBoolean("Settings.transaction-record");
     public boolean PAY_TIPS = false;
     public boolean USERNAME_IGNORE_CASE = config.getBoolean("Settings.username-ignore-case");
+    public DuplicateUsernameAction DUPLICATE_USERNAME_ACTION = DuplicateUsernameAction.KICK;
 
     public boolean NON_PLAYER_ACCOUNT = config.getBoolean("non-player-account.enable");
     public List<String> NON_PLAYER_ACCOUNT_SUBSTRING = null;
@@ -160,6 +163,21 @@ public class DefaultConfig {
     private void setpaytips() {
         if (TRANSACTION_RECORD) {
             PAY_TIPS = config.getBoolean("Settings.offline-pay-transfer-tips");
+        }
+    }
+
+    private void setDuplicateUsernameAction() {
+        if (!config.contains("Settings.duplicate-username-action")) {
+            return;
+        }
+        String action = config.getString("Settings.duplicate-username-action");
+        if (action == null) {
+            return;
+        }
+        if (action.equalsIgnoreCase("REPLACE")) {
+            DUPLICATE_USERNAME_ACTION = DuplicateUsernameAction.REPLACE;
+        } else if (action.equalsIgnoreCase("MOJANG")) {
+            DUPLICATE_USERNAME_ACTION = DuplicateUsernameAction.MOJANG;
         }
     }
 }

--- a/XConomy-Core/src/main/java/me/yic/xconomy/utils/DuplicateUsernameAction.java
+++ b/XConomy-Core/src/main/java/me/yic/xconomy/utils/DuplicateUsernameAction.java
@@ -1,0 +1,40 @@
+/*
+ *  This file (DuplicateUsernameAction.java) is a part of project XConomy
+ *  Copyright (C) YiC and contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package me.yic.xconomy.utils;
+
+public enum DuplicateUsernameAction {
+    /**
+     * Log an error and kick the connecting player (default behaviour).
+     */
+    KICK,
+
+    /**
+     * Remove the username from the old UUID entry and allow the new player to
+     * proceed. The old UUID record keeps its balance but gets a placeholder name
+     * (the UUID string) so it no longer conflicts.
+     */
+    REPLACE,
+
+    /**
+     * Remove the username from the old UUID entry, then query the Mojang API to
+     * find the old UUID's current username and update the old record with it.
+     * Falls back to REPLACE behaviour when the API is unreachable.
+     */
+    MOJANG
+}

--- a/XConomy-Core/src/main/resources/config.yml
+++ b/XConomy-Core/src/main/resources/config.yml
@@ -54,6 +54,17 @@ Settings:
   offline-pay-transfer-tips: false
   #Ignore the case of player names
   username-ignore-case: false
+  #Action to take when a duplicate username conflict is detected (same name, different UUID in the database).
+  #This can happen when a player renames their Minecraft account without logging in first,
+  #and a second player then claims that old name.
+  #KICK:    Log an error in the console and kick the connecting player (default).
+  #REPLACE: Remove the name from the old UUID entry and allow the new player to proceed.
+  #         The old UUID keeps its balance but its name becomes a placeholder until the
+  #         original owner logs in again and their name is refreshed automatically.
+  #MOJANG:  Like REPLACE, but also queries the Mojang API to look up the old UUID's
+  #         current username and stores that directly, so both accounts end up with the
+  #         correct name straight away. Falls back to REPLACE when the API is unreachable.
+  duplicate-username-action: KICK
 
 
 #It can solve the problem that some plugins need to create non-player accounts, such as Factions


### PR DESCRIPTION
## Summary
This PR adds configurable handling for duplicate username conflicts in the database. Previously, when a player with the same username but different UUID tried to join, they would always be kicked. Now administrators can choose from three resolution strategies via configuration.

## Key Changes
- **New enum `DuplicateUsernameAction`**: Defines three conflict resolution strategies:
  - `KICK`: Original behavior - log error and kick the connecting player
  - `REPLACE`: Rename the old UUID entry to a placeholder (UUID string) and allow the new player to proceed
  - `MOJANG`: Query Mojang API to find the old UUID's current username, update the database, and fall back to REPLACE if API is unavailable

- **Updated `SQLCreateNewAccount.checkUser()`**: Refactored duplicate username detection logic to use the new configurable action instead of always kicking

- **New helper methods in `SQLCreateNewAccount`**:
  - `resolveConflictReplace()`: Renames old entry to UUID placeholder
  - `resolveConflictMojang()`: Queries Mojang API and updates old entry with current username
  - `fetchCurrentUsernameFromMojang()`: Fetches current username from Mojang session server API

- **Configuration support in `DefaultConfig`**: Added `DUPLICATE_USERNAME_ACTION` field with config file parsing via `setDuplicateUsernameAction()`

- **Updated `config.yml`**: Added new `duplicate-username-action` setting with documentation explaining each option and when duplicate username conflicts occur

## Implementation Details
- The old UUID's balance is always preserved regardless of resolution strategy
- When using REPLACE or MOJANG strategies, the connecting player proceeds normally and `selectUser()` will update their name on next login if needed
- MOJANG strategy gracefully falls back to REPLACE behavior when the Mojang API is unreachable
- Comprehensive logging is added for all conflict resolution actions
- The SEMIONLINE UUID mode continues to use the existing `createDUUIDLink()` behavior